### PR TITLE
Форматирование разрядов чисел

### DIFF
--- a/mods/ProperRussian/lovely.toml
+++ b/mods/ProperRussian/lovely.toml
@@ -230,6 +230,14 @@ payload = '''label = localize('Diamonds', 'suits_singular'),'''
 overwrite = true
 match_indent = true
 
+# Замена форматирования разрядов чисел с запятых на пробелы (1,000 => 1 000)
+[[patches]]
+[patches.regex]
+target = "functions/misc_functions.lua"
+pattern = 'gsub\("\(%d%d%d\)"\, "%1,"\):gsub\("\,\$"\, ""\)'
+position = "at"
+payload = 'gsub("(%d%d%d)", "%1 "):gsub(" $", "")'
+
 # Добавление ссылки на локализацию в меню Авторы
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
Этот PR меняет формат разрядов чисел на соответствующий региональному формату, заменяя запятые в разделителе разрядов на пробелы (1,000 -> 1 000).

По какой-то причине корректная замена производится только через regex вместо pattern. Замена совместима как с чистым Lovely-инжектором, так и с установленным Steamodded.